### PR TITLE
fixed: error when Duration is empty

### DIFF
--- a/lib/ui/player/presentation/player_page.dart
+++ b/lib/ui/player/presentation/player_page.dart
@@ -39,6 +39,7 @@ class PlayerContent extends StatefulWidget {
 class _PlayerContentState extends State<PlayerContent> {
   Duration duration = const Duration(seconds: 1);
   Duration position = const Duration(seconds: 0);
+  Duration empty = const Duration(hours: -286, minutes: -53, seconds: -18);
 
   @override
   void initState() {
@@ -56,7 +57,8 @@ class _PlayerContentState extends State<PlayerContent> {
   _getDuration() async {
     double rawDuration = await widget.appBloc.audioPlayer.getDuration() / 1000;
     Duration parsedDurtion = Duration(seconds: (rawDuration).round());
-    if (mounted) {
+    final hasDuration = parsedDurtion.compareTo(empty) != 0 ? true : false;
+    if (mounted && hasDuration) {
       setState(() {
         duration = parsedDurtion;
       });


### PR DESCRIPTION
When bringing the duration of a podcast before it started, it had a format:

```
Duration(hours: -286, minutes: -53, seconds: -18)
```

and caused the following error in the Slider() widget:

![Error](https://user-images.githubusercontent.com/67238016/154178617-bdbba1cc-9dca-4341-ae88-fc3f1360db00.jpeg)

To solve it, I made a validation that avoids setting the **parsedDurtion** value if it is empty.

```
final hasDuration = parsedDurtion.compareTo(empty) != 0 ? true : false;
    if (mounted && hasDuration) {
      setState(() {
        duration = parsedDurtion;
      });
    }
```